### PR TITLE
fix:在作业查询接口加入了正则表达式的格式检查，若格式错误则返回400状态码及正则表达式不合法信息

### DIFF
--- a/src/main/kotlin/plus/maa/backend/controller/CopilotController.kt
+++ b/src/main/kotlin/plus/maa/backend/controller/CopilotController.kt
@@ -27,6 +27,7 @@ import plus.maa.backend.controller.response.MaaResult.Companion.success
 import plus.maa.backend.controller.response.copilot.CopilotInfo
 import plus.maa.backend.controller.response.copilot.CopilotPageInfo
 import plus.maa.backend.service.CopilotService
+import java.util.regex.PatternSyntaxException
 
 /**
  * @author LoMu
@@ -72,7 +73,11 @@ class CopilotController(
     fun queriesCopilot(@ParameterObject parsed: @Valid CopilotQueriesRequest): MaaResult<CopilotPageInfo> {
         // 三秒防抖，缓解前端重复请求问题
         response.setHeader(HttpHeaders.CACHE_CONTROL, "private, max-age=3, must-revalidate")
-        return success(copilotService.queriesCopilot(helper.obtainUserId(), parsed))
+        return try {
+            success(copilotService.queriesCopilot(helper.obtainUserId(), parsed))
+        } catch (e: PatternSyntaxException) {
+            fail(400, "正则表达式不合法")
+        }
     }
 
     @Operation(summary = "更新作业")

--- a/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
+++ b/src/main/kotlin/plus/maa/backend/service/CopilotService.kt
@@ -272,6 +272,7 @@ class CopilotService(
 
         // 标题、描述、神秘代码
         if (!request.document.isNullOrBlank()) {
+            Pattern.compile(request.document)
             orQueries.add(Criteria.where("doc.title").regex(caseInsensitive(request.document)))
             orQueries.add(Criteria.where("doc.details").regex(caseInsensitive(request.document)))
         }


### PR DESCRIPTION
Java原生的正则表达式解析工具方法Pattern.compile()可以按照正则表达式解析字符串，该方法在正则表达式不合法时会抛出PatternSyntaxException。因此在按照正则表达式查询之前尝试调用该方法，若捕获到PatternSyntaxException异常说明解析失败，即表达式不合法，返回包括400状态码和错误信息的fail结果。