### PR TITLE
feat: update json schema

### DIFF
--- a/src/main/resources/static/templates/maa-copilot-schema.json
+++ b/src/main/resources/static/templates/maa-copilot-schema.json
@@ -60,8 +60,7 @@
         },
         "details": {
           "type": "string",
-          "description": "Operation description",
-          "minLength": 1
+          "description": "Operation description"
         },
         "title_color": {
           "type": "string",
@@ -138,7 +137,6 @@
           "type": "integer",
           "description": "Module requirement, optional, 0 by default",
           "minimum": 0,
-          "maximum": 1,
           "default": 0
         },
         "potentiality": {
@@ -212,8 +210,7 @@
         },
         "cost_changes": {
           "type": "integer",
-          "description": "Waiting until the cost changes for the amount specified, optional, 0 by default.",
-          "minimum": 0
+          "description": "Waiting until the cost changes for the amount specified, optional, 0 by default."
         },
         "cooling": {
           "type": "integer",
@@ -271,6 +268,12 @@
           "default": 0
         },
         "rear_delay": {
+          "type": "integer",
+          "description": "Post-delay in ms, optional, 0 by default.",
+          "minimum": 0,
+          "default": 0
+        },
+        "post_delay": {
           "type": "integer",
           "description": "Post-delay in ms, optional, 0 by default.",
           "minimum": 0,


### PR DESCRIPTION
- 取消模组上限
- 允许费用变化量为负数
- 添加 `post_delay`
- 允许 `details` 为空 <- 这个不知道对后端有没有影响，主要是觉得没必要强制让用户填写